### PR TITLE
Config data model w/ writing through beast.go

### DIFF
--- a/beast.go
+++ b/beast.go
@@ -31,6 +31,8 @@ func main() {
 	switch os.Args[1] {
 	case "help":
 		cmd.Help()
+	case "config":
+		cmd.WriteDefaultConfig()
 	case "run":
 		runCmd(os.Args[2:])
 	case "generate":

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/jjmrocha/beast/models"
+)
+
+func WriteDefaultConfig() error {
+	f, err := os.Create("config.json")
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(f).Encode(models.NewDefaultConfig())
+}

--- a/models/config.go
+++ b/models/config.go
@@ -1,0 +1,17 @@
+package models
+
+// Config contains the parameters for setting up a HTTP Connection
+type Config struct {
+	DisableCompression bool `json:"disable-compression"`
+	DisableKeepAlives  bool `json:"disable-keep-alives"`
+	MaxConnections     int  `json:"max-connections"`
+	Timeout            uint `json:"timeout"`
+}
+
+// NewDefaultConfig creates a default config file
+func NewDefaultConfig() Config {
+	return Config{
+		DisableCompression: true,
+		Timeout:            30,
+	}
+}


### PR DESCRIPTION
Fixes issue #17

I created a config package within the project, to store the config data structure. In the cmd package, I added a function which writes the default config values to a file. This function is called through the main function, with the 'config' command-line parameter.